### PR TITLE
チャットルーム管理機能およびメッセージ投稿機能の実装

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ApplicationRecord
+end

--- a/db/migrate/20220903054301_create_messages.rb
+++ b/db/migrate/20220903054301_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string  :content
+      t.references :room, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :message do
+    
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# what
・チャットルーム管理機能およびメッセージ投稿機能の実装
・Basic認証の導入
# why
・メッセージをやりとりできる機能とチャットルームを作成できるようにするため
・閲覧できるユーザーを制限するためにBasic認証を導入