### PR TITLE
authenticate_userの訂正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
-  
+  before_action :authenticate_user!
+
   def index
   
   end


### PR DESCRIPTION
# what
・authenticate_userの訂正
#why
・トップ画面に遷移されずにログイン画面が先に出てきてしまっていたため